### PR TITLE
Add watchOS 6 to the platforms

### DIFF
--- a/Nimble-SnapshotTesting.podspec
+++ b/Nimble-SnapshotTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Nimble-SnapshotTesting'
-  s.version          = '4.0.2'
+  s.version          = '4.0.3'
   s.summary          = 'A Nimble matcher for snapshot testing'
   s.description      = <<-DESC
   A Nimble matcher for snapshot testing library.

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "Nimble-SnapshotTesting",
-    platforms: [.iOS(.v13), .tvOS(.v13), .macOS(.v10_15)],
+    platforms: [.iOS(.v13), .tvOS(.v13), .macOS(.v10_15), .watchOS(.v6)],
     products: [
         .library(
             name: "Nimble-SnapshotTesting",


### PR DESCRIPTION
watchOS is supported by snapshot testing so it can be added