### PR TITLE
Allow minor updates to Nimble

### DIFF
--- a/Nimble-SnapshotTesting.podspec
+++ b/Nimble-SnapshotTesting.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
   s.frameworks = "Foundation", "XCTest", "UIKit"
   s.dependency "SnapshotTesting"
-  s.dependency "Nimble", '~> 13.0.0'
+  s.dependency "Nimble", '~> 13.0'
 
   s.ios.deployment_target = '13.0'
   s.swift_versions = [5.0, 5.1, 5.2, 5.3, 5.4]


### PR DESCRIPTION
Currently it is locking to only patch updates. This change will allow minor updates up to 14.0