### PR TITLE
Make record option optional to support environment variable

### DIFF
--- a/Sources/Nimble-SnapshotTesting/HaveValidSnapshot.swift
+++ b/Sources/Nimble-SnapshotTesting/HaveValidSnapshot.swift
@@ -3,7 +3,7 @@ import Nimble
 @_exported import SnapshotTesting
 
 /// The global recording mode for all snapshot tests
-nonisolated(unsafe) public var isRecordingSnapshots: Bool = false
+nonisolated(unsafe) public var isRecordingSnapshots: Bool? = nil
 // we are assuming the risk of modifying it from differen threads
 
 /// A counter is used internally for keeping track of unique test cases. Otherwise, we would end up with the library recording
@@ -36,7 +36,7 @@ private enum Counter {
 public func haveValidSnapshot<Value, Format>(
     as strategy: Snapshotting<Value, Format>,
     named name: String? = nil,
-    record: Bool = false,
+    record: Bool? = nil,
     snapshotDirectory: String? = nil,
     timeout: TimeInterval = 5,
     file: StaticString = #file,
@@ -46,7 +46,7 @@ public func haveValidSnapshot<Value, Format>(
 ) -> Matcher<Value> {
     haveValidSnapshot(as: [strategy],
                       named: name,
-                      record: isRecordingSnapshots || record,
+                      record: isRecordingSnapshots ?? record,
                       snapshotDirectory: snapshotDirectory,
                       timeout: timeout,
                       file: file,
@@ -71,7 +71,7 @@ public func haveValidSnapshot<Value, Format>(
 public func haveValidSnapshot<Value, Format>(
     as strategies: [Snapshotting<Value, Format>],
     named name: String? = nil,
-    record: Bool = false,
+    record: Bool? = nil,
     snapshotDirectory: String? = nil,
     timeout: TimeInterval = 5,
     file: StaticString = #file,
@@ -92,7 +92,7 @@ public func haveValidSnapshot<Value, Format>(
             if let errorMessage = verifySnapshot(of: value,
                                                  as: strategy,
                                                  named: name ?? testCaseIdentifier(line: line),
-                                                 record: isRecordingSnapshots || record,
+                                                 record: isRecordingSnapshots ?? record,
                                                  timeout: timeout,
                                                  file: file,
                                                  testName: testName,
@@ -128,7 +128,7 @@ public extension SyncExpectation {
                                         timeout: NimbleTimeInterval = PollingDefaults.timeout,
                                         pollInterval: NimbleTimeInterval = PollingDefaults.snapshotPollInterval,
                                         description: String? = nil) {
-        if isRecordingSnapshots {
+        if isRecordingSnapshots == true {
             to(matcher, description: description)
         }
         else {
@@ -146,7 +146,7 @@ public extension SyncExpectation {
                                         timeout: NimbleTimeInterval = PollingDefaults.timeout,
                                         pollInterval: NimbleTimeInterval = PollingDefaults.snapshotPollInterval,
                                         description: String? = nil) async {
-        if isRecordingSnapshots {
+        if isRecordingSnapshots == true {
             to(matcher, description: description)
         }
         else {
@@ -181,7 +181,7 @@ public func haveValidSnapshot<Value, Format>(
 ) -> Matcher<Value> {
     haveValidSnapshot(as: [strategy],
                       named: name,
-                      record: isRecordingSnapshots || record,
+                      record: isRecordingSnapshots ?? record,
                       recordDelay: recordDelay,
                       snapshotDirectory: snapshotDirectory,
                       timeout: timeout,
@@ -244,10 +244,10 @@ public func haveValidSnapshot<Value, Format>(
     function: String = #function
 ) -> Matcher<Value> {
     
-    if isRecordingSnapshots || record {
+    if (isRecordingSnapshots ?? record) == true {
         return haveValidSnapshot(as: strategies.map { .wait(for: recordDelay, on: $0) },
                                  named: name,
-                                 record: isRecordingSnapshots || record,
+                                 record: isRecordingSnapshots ?? record,
                                  snapshotDirectory: snapshotDirectory,
                                  timeout: timeout,
                                  file: file,
@@ -258,7 +258,7 @@ public func haveValidSnapshot<Value, Format>(
     else {
         return haveValidSnapshot(as: strategies,
                                  named: name,
-                                 record: isRecordingSnapshots || record,
+                                 record: isRecordingSnapshots ?? record,
                                  snapshotDirectory: snapshotDirectory,
                                  timeout: timeout,
                                  file: file,

--- a/Sources/Nimble-SnapshotTesting/PrettySyntax.swift
+++ b/Sources/Nimble-SnapshotTesting/PrettySyntax.swift
@@ -7,7 +7,7 @@ import SnapshotTesting
 public struct Snapshot<Value, Format> {
     let strategies: [Snapshotting<Value, Format>]
     let name: String?
-    let record: Bool
+    let record: Bool?
     let timeout: TimeInterval
     let file: StaticString
     let line: UInt
@@ -15,7 +15,7 @@ public struct Snapshot<Value, Format> {
 
     public init(on strategies: [Snapshotting<Value, Format>],
                 name: String? = nil,
-                record: Bool = false,
+                record: Bool? = nil,
                 timeout: TimeInterval = 5,
                 file: StaticString = #file,
                 line: UInt = #line,
@@ -32,14 +32,14 @@ public struct Snapshot<Value, Format> {
 
 public func snapshot<Value, Format>(on strategy: Snapshotting<Value, Format>,
                                     name: String? = nil,
-                                    record: Bool = false,
+                                    record: Bool? = nil,
                                     timeout: TimeInterval = 5,
                                     file: StaticString = #file,
                                     line: UInt = #line,
                                     function: String = #function) -> Snapshot<Value, Format> {
     snapshot(on: [strategy],
              name: name,
-             record: isRecordingSnapshots || record,
+             record: isRecordingSnapshots ?? record,
              timeout: timeout,
              file: file,
              line: line,
@@ -49,14 +49,14 @@ public func snapshot<Value, Format>(on strategy: Snapshotting<Value, Format>,
 
 public func snapshot<Value, Format>(on strategies: [Snapshotting<Value, Format>],
                                     name: String? = nil,
-                                    record: Bool = false,
+                                    record: Bool? = nil,
                                     timeout: TimeInterval = 5,
                                     file: StaticString = #file,
                                     line: UInt = #line,
                                     function: String = #function) -> Snapshot<Value, Format> {
     Snapshot(on: strategies,
              name: name,
-             record: isRecordingSnapshots || record,
+             record: isRecordingSnapshots ?? record,
              timeout: timeout,
              file: file,
              line: line,


### PR DESCRIPTION
`swift-snapshot-testing` supports `SNAPSHOT_TESTING_RECORD` environment variable since 1.17.0 and if using this library this feature was not working because record would be passed in as `false` by default.

Changing default value to `nil` to make sure if the environment variable is passed, it is used.