### PR TITLE
Rename snapshot(on: methods to snapshot(as:

### DIFF
--- a/Sources/Nimble-SnapshotTesting/PrettySyntax.swift
+++ b/Sources/Nimble-SnapshotTesting/PrettySyntax.swift
@@ -13,7 +13,24 @@ public struct Snapshot<Value, Format> {
     let line: UInt
     let function: String
 
+    @available(*, deprecated, renamed: "init(as:name:record:timeout:file:line:function:)", message: "Renamed to align initializer name with haveValidSnapshot method")
     public init(on strategies: [Snapshotting<Value, Format>],
+                name: String? = nil,
+                record: Bool? = nil,
+                timeout: TimeInterval = 5,
+                file: StaticString = #file,
+                line: UInt = #line,
+                function: String = #function) {
+        self.strategies = strategies
+        self.name = name
+        self.record = record
+        self.timeout = timeout
+        self.file = file
+        self.line = line
+        self.function = function
+    }
+
+    public init(as strategies: [Snapshotting<Value, Format>],
                 name: String? = nil,
                 record: Bool? = nil,
                 timeout: TimeInterval = 5,
@@ -30,6 +47,7 @@ public struct Snapshot<Value, Format> {
     }
 }
 
+@available(*, deprecated, renamed: "snapshot(as:name:record:timeout:file:line:function:)", message: "Renamed to align initializer name with haveValidSnapshot method")
 public func snapshot<Value, Format>(on strategy: Snapshotting<Value, Format>,
                                     name: String? = nil,
                                     record: Bool? = nil,
@@ -37,7 +55,7 @@ public func snapshot<Value, Format>(on strategy: Snapshotting<Value, Format>,
                                     file: StaticString = #file,
                                     line: UInt = #line,
                                     function: String = #function) -> Snapshot<Value, Format> {
-    snapshot(on: [strategy],
+    snapshot(as: [strategy],
              name: name,
              record: isRecordingSnapshots ?? record,
              timeout: timeout,
@@ -47,6 +65,24 @@ public func snapshot<Value, Format>(on strategy: Snapshotting<Value, Format>,
     )
 }
 
+public func snapshot<Value, Format>(as strategy: Snapshotting<Value, Format>,
+                                    name: String? = nil,
+                                    record: Bool? = nil,
+                                    timeout: TimeInterval = 5,
+                                    file: StaticString = #file,
+                                    line: UInt = #line,
+                                    function: String = #function) -> Snapshot<Value, Format> {
+    snapshot(as: [strategy],
+             name: name,
+             record: isRecordingSnapshots ?? record,
+             timeout: timeout,
+             file: file,
+             line: line,
+             function: function
+    )
+}
+
+@available(*, deprecated, renamed: "snapshot(as:name:record:timeout:file:line:function:)", message: "Renamed to align initializer name with haveValidSnapshot method")
 public func snapshot<Value, Format>(on strategies: [Snapshotting<Value, Format>],
                                     name: String? = nil,
                                     record: Bool? = nil,
@@ -54,7 +90,24 @@ public func snapshot<Value, Format>(on strategies: [Snapshotting<Value, Format>]
                                     file: StaticString = #file,
                                     line: UInt = #line,
                                     function: String = #function) -> Snapshot<Value, Format> {
-    Snapshot(on: strategies,
+    Snapshot(as: strategies,
+             name: name,
+             record: isRecordingSnapshots ?? record,
+             timeout: timeout,
+             file: file,
+             line: line,
+             function: function
+    )
+}
+
+public func snapshot<Value, Format>(as strategies: [Snapshotting<Value, Format>],
+                                    name: String? = nil,
+                                    record: Bool? = nil,
+                                    timeout: TimeInterval = 5,
+                                    file: StaticString = #file,
+                                    line: UInt = #line,
+                                    function: String = #function) -> Snapshot<Value, Format> {
+    Snapshot(as: strategies,
              name: name,
              record: isRecordingSnapshots ?? record,
              timeout: timeout,

--- a/Tests/Nimble-SnapshotTestingTests/SnapshotsSpec.swift
+++ b/Tests/Nimble-SnapshotTestingTests/SnapshotsSpec.swift
@@ -29,8 +29,8 @@ final class SnapshotsSpecs: QuickSpec {
                 it("should support == syntax") {
                     let other = UILabel()
                     other.text = "Hello testing"
-
-                    expect(other) == snapshot(on: .image)
+                    
+                    expect(other) == snapshot(as: .image)
                 }
 
                 it("should work with toEventually") {
@@ -47,7 +47,7 @@ final class SnapshotsSpecs: QuickSpec {
                 it("should record snapshot of a codable") {
                     let object = TestCodable(stringValue: "What is the meaning of life", number: 42)
 
-                    expect(object) == snapshot(on: .json)
+                    expect(object) == snapshot(as: .json)
                 }
 
                 it("should record snapshot of a SwiftUI view") {


### PR DESCRIPTION
To align the naming between `haveValidSnapshot(as:` and snapshot method for `==` operator, rename the method name to `snapshot(as:` 