### PR TITLE
Force @MainActor for tests

### DIFF
--- a/Sources/Nimble-SnapshotTesting/HaveValidSnapshot.swift
+++ b/Sources/Nimble-SnapshotTesting/HaveValidSnapshot.swift
@@ -39,7 +39,7 @@ enum Counter {
 ///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
 ///   - function: The function name. This is used as a fallback if the currently running test is not found
 /// - Returns: A matcher to use in Nimble
-public func haveValidSnapshot<Value, Format>(
+@MainActor public func haveValidSnapshot<Value, Format>(
     as strategy: Snapshotting<Value, Format>,
     named name: String? = nil,
     record: Bool? = nil,
@@ -74,7 +74,7 @@ public func haveValidSnapshot<Value, Format>(
 ///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
 ///   - function: The function name. This is used as a fallback if the currently running test is not found
 /// - Returns: A matcher to use in Nimble
-public func haveValidSnapshot<Value, Format>(
+@MainActor public func haveValidSnapshot<Value, Format>(
     as strategies: [Snapshotting<Value, Format>],
     named name: String? = nil,
     record: Bool? = nil,
@@ -174,7 +174,7 @@ public extension SyncExpectation {
 ///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
 ///   - function: The function name. This is used as a fallback if the currently running test is not found
 /// - Returns: A matcher to use in Nimble
-public func haveValidSnapshot<Value, Format>(
+@MainActor public func haveValidSnapshot<Value, Format>(
     as strategy: Snapshotting<Value, Format>,
     named name: String? = nil,
     record: Bool? = nil,
@@ -240,7 +240,7 @@ private func testCaseIdentifier(line: UInt) -> String {
 ///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
 ///   - function: The function name. This is used as a fallback if the currently running test is not found
 /// - Returns: A matcher to use in Nimble
-public func haveValidSnapshot<Value, Format>(
+@MainActor public func haveValidSnapshot<Value, Format>(
     as strategies: [Snapshotting<Value, Format>],
     named name: String? = nil,
     record: Bool? = nil,

--- a/Sources/Nimble-SnapshotTesting/PrettySyntax.swift
+++ b/Sources/Nimble-SnapshotTesting/PrettySyntax.swift
@@ -48,7 +48,7 @@ public struct Snapshot<Value, Format> {
 }
 
 @available(*, deprecated, renamed: "snapshot(as:name:record:timeout:file:line:function:)", message: "Renamed to align initializer name with haveValidSnapshot method")
-public func snapshot<Value, Format>(on strategy: Snapshotting<Value, Format>,
+@MainActor public func snapshot<Value, Format>(on strategy: Snapshotting<Value, Format>,
                                     name: String? = nil,
                                     record: Bool? = nil,
                                     timeout: TimeInterval = 5,
@@ -65,7 +65,7 @@ public func snapshot<Value, Format>(on strategy: Snapshotting<Value, Format>,
     )
 }
 
-public func snapshot<Value, Format>(as strategy: Snapshotting<Value, Format>,
+@MainActor public func snapshot<Value, Format>(as strategy: Snapshotting<Value, Format>,
                                     name: String? = nil,
                                     record: Bool? = nil,
                                     timeout: TimeInterval = 5,
@@ -83,7 +83,7 @@ public func snapshot<Value, Format>(as strategy: Snapshotting<Value, Format>,
 }
 
 @available(*, deprecated, renamed: "snapshot(as:name:record:timeout:file:line:function:)", message: "Renamed to align initializer name with haveValidSnapshot method")
-public func snapshot<Value, Format>(on strategies: [Snapshotting<Value, Format>],
+@MainActor public func snapshot<Value, Format>(on strategies: [Snapshotting<Value, Format>],
                                     name: String? = nil,
                                     record: Bool? = nil,
                                     timeout: TimeInterval = 5,
@@ -100,6 +100,7 @@ public func snapshot<Value, Format>(on strategies: [Snapshotting<Value, Format>]
     )
 }
 
+@MainActor
 public func snapshot<Value, Format>(as strategies: [Snapshotting<Value, Format>],
                                     name: String? = nil,
                                     record: Bool? = nil,
@@ -117,6 +118,7 @@ public func snapshot<Value, Format>(as strategies: [Snapshotting<Value, Format>]
     )
 }
 
+@MainActor
 public func == <Value, Format>(lhs: SyncExpectation<Value>, rhs: Snapshot<Value, Format>) {
     lhs.to(haveValidSnapshot(as: rhs.strategies,
                              named: rhs.name,


### PR DESCRIPTION
`SnapshotTesting` does not support recording snapshots on anything but the main actor so enforcing the `@MainActor` requirement so that all `AsyncSpec` force people to use `@MainActor` and `QuickSpec` just works as is.